### PR TITLE
Add initial docker build GH Action to fork's main branch for testing

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: "docker-build"
+
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: write 
+      packages: write 
+    steps:
+      - name: "Checkout source code"
+        uses: "actions/checkout@v2"
+      # - name: Set up Go
+      #   uses: actions/setup-go@v2
+      #   with:
+      #     go-version: 1.17
+      - name: "Build"
+        run: "make docker-build"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ghcr.io/jbowen93/dalc:latest
+          file: docker/Dockerfile


### PR DESCRIPTION
## Description

Take a first attempt to at the docker build GH action that will be immediately merged to the `main` branch. This is because a GH action cannot be actuated (and thus tested) it exists on the `main` branch. After it is initially created it can be modified and tested on different branches.  
