### PR TITLE
GH action to build and push `latest` docker image to ghcr on merge to `main`

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,5 +29,5 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/jbowen93/dalc:latest
+          tags: ghcr.io/celestiaorg/dalc:latest
           file: docker/Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,12 +15,6 @@ jobs:
     steps:
       - name: "Checkout source code"
         uses: "actions/checkout@v2"
-      # - name: Set up Go
-      #   uses: actions/setup-go@v2
-      #   with:
-      #     go-version: 1.17
-      - name: "Build"
-        run: "make docker-build"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/CHANGELOG-PENDING.md
+++ b/CHANGELOG-PENDING.md
@@ -26,3 +26,4 @@ Month, DD, YYYY
 - Add workflow_dispatch option to lintchecker GH action
 - Create placeholder init.md doc to be checked by lintchecker gh action
 - Add docker directory w/ Dockerfile and entrypoint.sh
+- Add GH Action to automatically create a `latest` tagged docker image and push it to ghcr.io/celestiaorg/dalc:latest on every merge to `main`

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build:
 .PHONY: build
 
 # Build DALC docker image
-build-docker:
+docker-build:
 	@docker build --platform linux/amd64 -f docker/Dockerfile -t ghcr.io/celestiaorg/dalc:latest .
 
 proto-all: proto-gen proto-lint

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,3 @@ proto-gen:
 .PHONY: proto-gen
 proto-lint:
 	@$(DOCKER_BUF) lint --error-format=json
-
-


### PR DESCRIPTION
## Description

Creates a GH action manifest that will run build and push a new docker image to ghcr.io/celestiaorg/dalc:latest on every merge to the `main` branch.

A successful run from the forked repo can be seen [here](https://github.com/jbowen93/dalc/actions/runs/1719651349)

closes #47 
