### PR TITLE
fix: Properly provide the GRPC server during dependency injection

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,9 @@ jobs:
             **/**.go
             go.mod
             go.sum
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
       - uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,39 +31,8 @@ jobs:
           path: ~/go/bin
           key: ${{ runner.os }}-go-tparse-binary
 
-  split-test-files:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Create a file with all the pkgs
-        run: go list ./... > pkgs.txt
-      - name: Split pkgs into 4 files
-        run: split -d -n l/4 pkgs.txt pkgs.txt.part.
-      # cache multiple
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-00"
-          path: ./pkgs.txt.part.00
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-01"
-          path: ./pkgs.txt.part.01
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-02"
-          path: ./pkgs.txt.part.02
-      - uses: actions/upload-artifact@v2
-        with:
-          name: "${{ github.sha }}-03"
-          path: ./pkgs.txt.part.03
-
   tests:
     runs-on: ubuntu-latest
-    needs: split-test-files
-    strategy:
-      fail-fast: false
-      matrix:
-        part: ["00", "01", "02", "03"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -75,26 +44,17 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-${{ matrix.part }}"
-        if: env.GIT_DIFF
       - name: test & coverage report creation
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic 
+          go test -mod=readonly -timeout 30m -coverprofile=profile.out -covermode=atomic ./...
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2
         with:
-          name: "${{ github.sha }}-${{ matrix.part }}-coverage"
-          path: ./${{ matrix.part }}profile.out
+          name: "${{ github.sha }}-coverage"
+          path: ./profile.out
 
   test-race:
     runs-on: ubuntu-latest
-    needs: split-test-files
-    strategy:
-      fail-fast: false
-      matrix:
-        part: ["00", "01", "02", "03"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -106,18 +66,14 @@ jobs:
             **/**.go
             go.mod
             go.sum
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-${{ matrix.part }}"
-        if: env.GIT_DIFF
       - name: test & coverage report creation
         run: |
-          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -mod=readonly -json -timeout 30m -race  > ${{ matrix.part }}-race-output.txt
+          go test -mod=readonly -json -timeout 30m -race ./... > race-output.txt
         if: env.GIT_DIFF
       - uses: actions/upload-artifact@v2
         with:
-          name: "${{ github.sha }}-${{ matrix.part }}-race-output"
-          path: ./${{ matrix.part }}-race-output.txt
+          name: "${{ github.sha }}-race-output"
+          path: ./race-output.txt
 
   race-detector-report:
     runs-on: ubuntu-latest
@@ -134,19 +90,7 @@ jobs:
             go.sum
       - uses: actions/download-artifact@v2
         with:
-          name: "${{ github.sha }}-00-race-output"
-        if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-01-race-output"
-        if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-02-race-output"
-        if: env.GIT_DIFF
-      - uses: actions/download-artifact@v2
-        with:
-          name: "${{ github.sha }}-03-race-output"
+          name: "${{ github.sha }}-race-output"
         if: env.GIT_DIFF
       - uses: actions/cache@v3
         with:
@@ -154,6 +98,6 @@ jobs:
           key: ${{ runner.os }}-go-tparse-binary
         if: env.GIT_DIFF
       - name: Generate test report (go test -race)
-        run: cat ./*-race-output.txt | ~/go/bin/tparse
+        run: cat race-output.txt | ~/go/bin/tparse
         if: env.GIT_DIFF
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/BurntSushi/toml v1.0.0
 	github.com/celestiaorg/celestia-app v0.0.0-00010101000000-000000000000
-	github.com/celestiaorg/celestia-node v0.0.0-20211110181526-447aac929993
+	github.com/celestiaorg/celestia-node v0.2.1-0.20220329162857-65faaea99787
 	github.com/celestiaorg/nmt v0.8.0
 	github.com/cosmos/cosmos-sdk v0.45.1
 	github.com/gogo/protobuf v1.3.3

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -6,6 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-node/node/fxutil"
 	"github.com/celestiaorg/dalc/config"
 	logging "github.com/ipfs/go-log/v2"
+	"go.uber.org/fx"
 )
 
 var log = logging.Logger("dalc/server")
@@ -32,9 +33,21 @@ func (onp *NodePlugin) Initialize(path string) error {
 }
 
 func (onp *NodePlugin) Components(cfg *node.Config, store node.Store) fxutil.Option {
+	configLoader, err := LoadConfig(store)
+	if err != nil {
+		log.Fatal(err)
+	}
+	annotated := fxutil.Raw(
+		fx.Provide(
+			fx.Annotate(
+				GRPCServer,
+				fx.ResultTags(`group:"plugins"`),
+			),
+		),
+	)
 	return fxutil.Options(
-		fxutil.Provide(LoadConfig),
+		fxutil.Provide(configLoader),
 		fxutil.Provide(DALC),
-		fxutil.Provide(GRPCServer),
+		annotated,
 	)
 }

--- a/server/services.go
+++ b/server/services.go
@@ -37,10 +37,12 @@ func GRPCServer(lc fx.Lifecycle, srv *grpc.Server, cfg config.ServerConfig) node
 				if err != nil {
 					return err
 				}
-				err = srv.Serve(lis)
-				if err != nil {
-					return err
-				}
+				go func() {
+					err = srv.Serve(lis)
+					if err != nil {
+						log.Fatal(err)
+					}
+				}()
 				return nil
 			},
 			OnStop: func(c context.Context) error {

--- a/server/services.go
+++ b/server/services.go
@@ -20,12 +20,12 @@ func DALC(
 	return New(cfg, ss, hstore)
 }
 
-func LoadConfig(store node.Store) (config.ServerConfig, error) {
+func LoadConfig(store node.Store) (func() config.ServerConfig, error) {
 	cfg, err := config.Load(store.Path())
 	if err != nil {
-		return config.ServerConfig{}, err
+		return func() config.ServerConfig { return config.ServerConfig{} }, err
 	}
-	return cfg, nil
+	return func() config.ServerConfig { return cfg }, nil
 }
 
 func GRPCServer(lc fx.Lifecycle, srv *grpc.Server, cfg config.ServerConfig) node.PluginResult {

--- a/server/test/integration_test.go
+++ b/server/test/integration_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	nodecmd "github.com/celestiaorg/celestia-node/cmd"
+	"github.com/celestiaorg/dalc/server"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+type IntegrationSuite struct {
+	suite.Suite
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     *sync.WaitGroup
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, newIntegrationTestSuite())
+}
+
+func newIntegrationTestSuite() *IntegrationSuite {
+	return &IntegrationSuite{}
+}
+
+func (s *IntegrationSuite) SetupTest() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	s.cancel = cancel
+	s.ctx = ctx
+	s.wg = &sync.WaitGroup{}
+
+	tmpDir := s.T().TempDir()
+
+	plugin := server.NodePlugin{}
+
+	root := nodecmd.NewRootCmd(&plugin)
+
+	root.SetArgs([]string{
+		"light",
+		"init",
+		"--node.store",
+		fmt.Sprintf("%s/.celestia-light", tmpDir),
+	})
+
+	if err := root.ExecuteContext(nodecmd.WithEnv(ctx)); err != nil {
+		log.Fatal(err)
+	}
+
+	root.SetArgs([]string{
+		"light",
+		"start",
+	})
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		if err := root.ExecuteContext(nodecmd.WithEnv(ctx)); err != nil {
+			if strings.Compare(err.Error(), "context canceled") == 0 {
+				return
+			}
+			log.Fatal(err)
+		}
+	}()
+	time.Sleep(time.Second * 15)
+}
+
+func (s *IntegrationSuite) TearDownSuite() {
+	s.T().Log("tearing down integration test suite")
+	s.cancel()
+	s.wg.Wait()
+}
+
+func (s *IntegrationSuite) TestPing() {
+	_, err := grpc.Dial("tcp://localhost:4200", grpc.WithInsecure())
+	s.NoError(err)
+}

--- a/server/test/integration_test.go
+++ b/server/test/integration_test.go
@@ -56,6 +56,8 @@ func (s *IntegrationSuite) SetupTest() {
 	root.SetArgs([]string{
 		"light",
 		"start",
+		"--node.store",
+		fmt.Sprintf("%s/.celestia-light", tmpDir),
 	})
 
 	s.wg.Add(1)


### PR DESCRIPTION
## Description

I forgot to properly annotate the last function in the dependency injection setup, so the grpc server wasn't being added. This wasn't needed on the previous verison of the celestia-node plugin, so while that version was tested, this was not. Waiting for more automated testing before merging.
