### PR TITLE
go get -> go install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: go version
       - name: install tparse
         run: |
-          export GO111MODULE="on" && go get github.com/mfridman/tparse@v0.8.3
+          export GO111MODULE="on" && go install github.com/mfridman/tparse@v0.8.3
       - uses: actions/cache@v3
         with:
           path: ~/go/bin


### PR DESCRIPTION
`go get` for binaries was deprecated in 1.17 and removed in 1.18 in favor of `go install`. https://go.dev/doc/go-get-install-deprecation