### PR TITLE
Ignore celestia binary build artifact.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dalc
+celestia


### PR DESCRIPTION
`celestia` is a build artifact from running `make build`. Ignore it.